### PR TITLE
Implement rudimentary regex voidlist support

### DIFF
--- a/Visibility/Configuration/VisibilityConfiguration.cs
+++ b/Visibility/Configuration/VisibilityConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 using Dalamud.Configuration;
 
@@ -8,7 +9,6 @@ using Lumina.Excel.Sheets;
 using Lumina.Text.ReadOnly;
 
 using Visibility.Handlers;
-using Visibility.Utils;
 using Visibility.Void;
 
 namespace Visibility.Configuration;
@@ -28,6 +28,8 @@ public partial class VisibilityConfiguration: IPluginConfiguration
 	public List<VoidItem> VoidList { get; } = [];
 
 	public List<VoidItem> Whitelist { get; } = [];
+
+	public List<VoidPattern> VoidPatterns { get; } = [];
 
 	[NonSerialized] public Dictionary<ulong, VoidItem> VoidDictionary = null!;
 	[NonSerialized] public Dictionary<ulong, VoidItem> WhitelistDictionary = null!;
@@ -49,7 +51,8 @@ public partial class VisibilityConfiguration: IPluginConfiguration
 	public void Init(ushort territoryType)
 	{
 		this.VoidDictionary = this.VoidList.Where(x => x.Id != 0).DistinctBy(x => x.Id).ToDictionary(x => x.Id, x => x);
-		this.WhitelistDictionary = this.Whitelist.Where(x => x.Id != 0).DistinctBy(x => x.Id).ToDictionary(x => x.Id, x => x);
+		this.WhitelistDictionary =
+			this.Whitelist.Where(x => x.Id != 0).DistinctBy(x => x.Id).ToDictionary(x => x.Id, x => x);
 		this.SettingsHandler = new SettingsHandler(this);
 
 		IEnumerable<(ushort, ReadOnlySeString)> valueTuples = Service.DataManager.GetExcelSheet<TerritoryType>()
@@ -68,7 +71,8 @@ public partial class VisibilityConfiguration: IPluginConfiguration
 	}
 
 	// Allowed territory intended use IDs
-	private static readonly HashSet<uint> allowedTerritoryIntendedUses = [
+	private static readonly HashSet<uint> allowedTerritoryIntendedUses =
+	[
 		0, // Hub Cities
 		1, // Overworld
 		13, // Residential Area
@@ -140,6 +144,7 @@ public partial class VisibilityConfiguration: IPluginConfiguration
 	}
 
 	public void Save() => Service.PluginInterface.SavePluginConfig(this);
-	[System.Text.RegularExpressions.GeneratedRegex("<italic\\(\\d+\\)>")]
-	private static partial System.Text.RegularExpressions.Regex ItalicRegex();
+
+	[GeneratedRegex("<italic\\(\\d+\\)>")]
+	private static partial Regex ItalicRegex();
 }

--- a/Visibility/Localization.cs
+++ b/Visibility/Localization.cs
@@ -189,6 +189,12 @@ public class Localization
 	public string AdvancedOption => this.GetString("AdvancedOption", this.CurrentLanguage);
 	public string AdvancedOptionTooltip => this.GetString("AdvancedOptionTooltip", this.CurrentLanguage);
 	public string ResetToCurrentArea => this.GetString("ResetToCurrentArea", this.CurrentLanguage);
+	
+	public string PatternListName => this.GetString("PatternListName", this.CurrentLanguage);
+	public string PatternName => this.GetString("PatternName", this.CurrentLanguage);
+	public string PatternDescription => this.GetString("PatternDescription", this.CurrentLanguage);
+	public string ActionAddPattern => this.GetString("ActionAddPattern", this.CurrentLanguage);
+	public string PatternOffworld => this.GetString("PatternOffworld", this.CurrentLanguage);
 
 	public SeString EntryAdded(string name, SeString entryName) =>
 		FormatSeString(this.GetString("EntryAdded", this.CurrentLanguage), name, entryName);

--- a/Visibility/Utils/FrameworkHandler.cs
+++ b/Visibility/Utils/FrameworkHandler.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 
 using Dalamud.Game.ClientState.Conditions;
-using Dalamud.Game.ClientState.Objects.Enums;
 
 using FFXIVClientStructs.FFXIV.Client.Game.Character;
 using FFXIVClientStructs.FFXIV.Client.Game.Control;
@@ -14,6 +13,7 @@ using FFXIVClientStructs.FFXIV.Component.GUI;
 
 using Visibility.Utils.EntityHandlers;
 
+using BattleNpcSubKind = Dalamud.Game.ClientState.Objects.Enums.BattleNpcSubKind;
 using ObjectKind = Dalamud.Game.ClientState.Objects.Enums.ObjectKind;
 
 namespace Visibility.Utils;
@@ -285,6 +285,15 @@ public class FrameworkHandler: IDisposable
 		if (!this.visibilityManager.IsObjectHidden(id)) return;
 
 		this.visibilityManager.MarkObjectToShow(id);
+	}
+
+	/// <summary>
+	/// Flushes the regex visibility cache and allows the visibility manager to recalculate all characters.
+	/// </summary>
+	public void ClearRegexCache()
+	{
+		this.voidListManager.ClearRegexCache();
+		this.visibilityManager.ClearAll();
 	}
 
 	/// <summary>

--- a/Visibility/Utils/ImGuiElements.cs
+++ b/Visibility/Utils/ImGuiElements.cs
@@ -9,7 +9,7 @@ namespace Visibility.Utils;
 
 public static class ImGuiElements
 {
-	public static bool Checkbox(bool value, string name)
+	public static bool Checkbox(bool value, string name, Action<bool, bool, bool>? callback = null)
 	{
 		if (!ImGui.Checkbox($"###{name}", ref value))
 		{
@@ -19,24 +19,30 @@ public static class ImGuiElements
 		Action<bool, bool, bool>? onValueChanged =
 			VisibilityPlugin.Instance.Configuration.SettingsHandler.GetAction(name);
 
-		if (onValueChanged == null)
+		if (onValueChanged != null)
 		{
-			return false;
+			onValueChanged(value, false, true);
+			VisibilityPlugin.Instance.Configuration.Save();
+			return true;
 		}
 
-		onValueChanged(value, false, true);
-		VisibilityPlugin.Instance.Configuration.Save();
-		return true;
+		if (callback != null)
+		{
+			callback(value, false, true);
+			return true;
+		}
+		
+		return false;
 	}
 
-	public static bool CenteredCheckbox(bool value, string name)
+	public static bool CenteredCheckbox(bool value, string name, Action<bool, bool, bool>? callback = null)
 	{
 		ImGui.SetCursorPosX(
 			ImGui.GetCursorPosX() +
 			((ImGui.GetColumnWidth() + (2 * ImGui.GetStyle().FramePadding.X)) / 2) -
 			(2 * ImGui.GetStyle().ItemSpacing.X) - (2 * ImGui.GetStyle().CellPadding.X));
 
-		return Checkbox(value, name);
+		return Checkbox(value, name, callback);
 	}
 
 	/// <summary>

--- a/Visibility/Void/VoidPattern.cs
+++ b/Visibility/Void/VoidPattern.cs
@@ -1,0 +1,24 @@
+﻿using System.Text.RegularExpressions;
+
+using Newtonsoft.Json;
+
+namespace Visibility.Void;
+
+[method: JsonConstructor]
+public class VoidPattern(
+	string id,
+	int version,
+	string pattern,
+	string description,
+	bool offworld = false,
+	bool enabled = true)
+{
+	public string Id { get; } = id;
+	public int Version { get; set; } = version;
+	public string Pattern { get; } = pattern;
+	public string Description { get; } = description;
+	public bool Offworld { get; set; } = offworld;
+	public bool Enabled { get; set; } = enabled;
+
+	[JsonIgnore] public readonly Regex Regex = new(pattern, RegexOptions.IgnoreCase | RegexOptions.Compiled);
+}

--- a/Visibility/Windows/Configuration.cs
+++ b/Visibility/Windows/Configuration.cs
@@ -17,9 +17,11 @@ public class Configuration: Window
 	{
 		this.whitelistWindow = new VoidItemList(isWhitelist: true);
 		this.voidItemListWindow = new VoidItemList(isWhitelist: false);
+		this.voidPatternWindow = new VoidPatternList();
 
 		windowSystem.AddWindow(this.whitelistWindow);
 		windowSystem.AddWindow(this.voidItemListWindow);
+		windowSystem.AddWindow(this.voidPatternWindow);
 
 		this.Size = new Vector2(700 * ImGui.GetIO().FontGlobalScale, 0);
 		this.SizeCondition = ImGuiCond.Always;
@@ -35,6 +37,7 @@ public class Configuration: Window
 
 	private readonly VoidItemList whitelistWindow;
 	private readonly VoidItemList voidItemListWindow;
+	private readonly VoidPatternList voidPatternWindow;
 
 	public override void Draw()
 	{
@@ -290,7 +293,8 @@ public class Configuration: Window
 			ImGui.GetContentRegionMax().X -
 			ImGui.CalcTextSize(VisibilityPlugin.Instance.PluginLocalization.WhitelistName).X -
 			ImGui.CalcTextSize(VisibilityPlugin.Instance.PluginLocalization.VoidListName).X -
-			(4 * ImGui.GetStyle().FramePadding.X) -
+			ImGui.CalcTextSize(VisibilityPlugin.Instance.PluginLocalization.PatternListName).X -
+			(8 * ImGui.GetStyle().FramePadding.X) -
 			(ImGui.GetStyle().ItemSpacing.X * ImGui.GetIO().FontGlobalScale));
 
 		if (ImGui.Button(VisibilityPlugin.Instance.PluginLocalization.WhitelistName))
@@ -301,11 +305,22 @@ public class Configuration: Window
 		ImGui.SameLine(
 			ImGui.GetContentRegionMax().X -
 			ImGui.CalcTextSize(VisibilityPlugin.Instance.PluginLocalization.VoidListName).X -
-			(2 * ImGui.GetStyle().FramePadding.X));
+			ImGui.CalcTextSize(VisibilityPlugin.Instance.PluginLocalization.PatternListName).X -
+			(6 * ImGui.GetStyle().FramePadding.X));
 
 		if (ImGui.Button(VisibilityPlugin.Instance.PluginLocalization.VoidListName))
 		{
 			this.voidItemListWindow.Toggle();
+		}
+		
+		ImGui.SameLine(
+			ImGui.GetContentRegionMax().X -
+			ImGui.CalcTextSize(VisibilityPlugin.Instance.PluginLocalization.PatternListName).X -
+			(2 * ImGui.GetStyle().FramePadding.X));
+
+		if (ImGui.Button(VisibilityPlugin.Instance.PluginLocalization.PatternListName))
+		{
+			this.voidPatternWindow.Toggle();
 		}
 	}
 }

--- a/Visibility/Windows/VoidPatternList.cs
+++ b/Visibility/Windows/VoidPatternList.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+
+using Dalamud.Bindings.ImGui;
+using Dalamud.Interface.Windowing;
+
+using Visibility.Configuration;
+using Visibility.Utils;
+using Visibility.Void;
+
+namespace Visibility.Windows;
+
+public class VoidPatternList: Window
+{
+	public VoidPatternList(): base(
+		$"{VisibilityPlugin.Instance.Name}: ", 0, true)
+	{
+		this.WindowName += VisibilityPlugin.Instance.PluginLocalization.PatternListName;
+		this.Size = new Vector2(700, 500);
+		this.SizeCondition = ImGuiCond.FirstUseEver;
+	}
+
+	private bool sortAscending;
+	private IEnumerable<VoidPattern>? sortedContainer;
+	private Func<VoidPattern, object>? sortKeySelector;
+
+	private readonly byte[][] buffer = { new byte[128], new byte[128] };
+
+	public override void Draw()
+	{
+		if (!ImGui.BeginTable(
+			    "PatternVoidListTable",
+			    5,
+			    ImGuiTableFlags.RowBg | ImGuiTableFlags.ScrollY | ImGuiTableFlags.Sortable))
+		{
+			return;
+		}
+
+		ImGui.TableSetupColumn(VisibilityPlugin.Instance.PluginLocalization.PatternName);
+		ImGui.TableSetupColumn(VisibilityPlugin.Instance.PluginLocalization.PatternDescription);
+		ImGui.TableSetupColumn(VisibilityPlugin.Instance.PluginLocalization.PatternOffworld);
+		ImGui.TableSetupColumn(VisibilityPlugin.Instance.PluginLocalization.OptionEnable);
+		ImGui.TableSetupColumn(VisibilityPlugin.Instance.PluginLocalization.ColumnAction, ImGuiTableColumnFlags.NoSort);
+		ImGui.TableSetupScrollFreeze(0, 1);
+		ImGui.TableHeadersRow();
+
+		VoidPattern? itemToRemove = null;
+
+		VisibilityConfiguration configuration = VisibilityPlugin.Instance.Configuration;
+
+		List<VoidPattern> container = configuration.VoidPatterns;
+		this.sortedContainer ??= container;
+
+		ImGuiTableSortSpecsPtr sortSpecs = ImGui.TableGetSortSpecs();
+
+		if (sortSpecs.SpecsDirty)
+		{
+			this.sortAscending = sortSpecs.Specs.SortDirection == ImGuiSortDirection.Ascending;
+
+			this.sortedContainer = sortSpecs.Specs.ColumnIndex switch
+			{
+				0 => SortContainer(
+					container,
+					x => x.Pattern,
+					this.sortAscending,
+					out this.sortKeySelector),
+				1 => SortContainer(
+					container,
+					x => x.Description,
+					this.sortAscending,
+					out this.sortKeySelector),
+				2 => SortContainer(
+					container,
+					x => x.Enabled,
+					this.sortAscending,
+					out this.sortKeySelector),
+				_ => this.sortedContainer
+			};
+
+			sortSpecs.SpecsDirty = false;
+		}
+
+		foreach (VoidPattern item in this.sortedContainer)
+		{
+			ImGui.TableNextColumn();
+			ImGui.TextUnformatted(item.Pattern);
+			ImGui.TableNextColumn();
+			ImGui.TextUnformatted(item.Description);
+			ImGui.TableNextColumn();
+			ImGuiElements.CenteredCheckbox(
+				item.Offworld,
+				$"VoidPattern##{item.Id}##Offworld",
+				((value, _, _) =>
+				{
+					item.Offworld = value;
+					configuration.Save();
+					// Refresh and recalculate visibility
+					VisibilityPlugin.Instance.FrameworkHandler.ClearRegexCache();
+				}));
+			ImGui.TableNextColumn();
+			ImGuiElements.CenteredCheckbox(
+				item.Enabled,
+				$"VoidPattern##{item.Id}##Enabled",
+				((value, _, _) =>
+				{
+					item.Enabled = value;
+					configuration.Save();
+					// Refresh and recalculate visibility
+					VisibilityPlugin.Instance.FrameworkHandler.ClearRegexCache();
+				}));
+			ImGui.TableNextColumn();
+
+			if (ImGui.Button(
+				    $"{VisibilityPlugin.Instance.PluginLocalization.OptionRemovePlayer}##{item.Id}"))
+			{
+				itemToRemove = item;
+			}
+
+			ImGui.TableNextRow();
+		}
+
+		if (itemToRemove != null)
+		{
+			container.Remove(itemToRemove);
+			configuration.Save();
+
+			if (this.sortKeySelector != null)
+			{
+				this.sortedContainer = SortContainer(
+					container,
+					this.sortKeySelector,
+					this.sortAscending,
+					out this.sortKeySelector);
+			}
+
+			// Refresh and recalculate visibility
+			VisibilityPlugin.Instance.FrameworkHandler.ClearRegexCache();
+		}
+
+		bool enabled = true;
+		bool offworld = true;
+
+		ImGui.TableNextColumn();
+		ImGui.InputText(
+			"###voidPattern",
+			this.buffer[0]);
+		ImGui.TableNextColumn();
+		ImGui.InputText(
+			"###voidPatternReason",
+			this.buffer[1]);
+		ImGui.TableNextColumn();
+		ImGuiElements.CenteredCheckbox(
+			offworld,
+			"###voidPatternOffworld");
+		ImGui.TableNextColumn();
+		ImGuiElements.CenteredCheckbox(
+			enabled,
+			"###voidPatternEnabled");
+		ImGui.TableNextColumn();
+
+		if (ImGui.Button(VisibilityPlugin.Instance.PluginLocalization.ActionAddPattern))
+		{
+			VoidPattern pattern;
+			try
+			{
+				pattern = new(
+					Guid.NewGuid().ToString(),
+					0,
+					this.buffer[0].ByteToString(),
+					this.buffer[1].ByteToString(),
+					enabled);
+			}
+			catch (Exception ex)
+			{
+				Service.PluginLog.Error($"Error registering pattern {this.buffer[0].ByteToString()}:\n{ex}");
+				return;
+			}
+
+			configuration.VoidPatterns.Add(pattern);
+			configuration.Save();
+
+			VisibilityPlugin.Instance.FrameworkHandler.ClearRegexCache();
+
+			foreach (byte[] item in this.buffer)
+			{
+				Array.Clear(item, 0, item.Length);
+			}
+
+			if (this.sortKeySelector != null)
+			{
+				this.sortedContainer = SortContainer(
+					container,
+					this.sortKeySelector,
+					this.sortAscending,
+					out this.sortKeySelector);
+			}
+		}
+
+		ImGui.EndTable();
+	}
+
+	private static IEnumerable<VoidPattern> SortContainer(
+		IEnumerable<VoidPattern> container,
+		Func<VoidPattern, object> keySelector,
+		bool isAscending,
+		out Func<VoidPattern, object> keySelectorOut)
+	{
+		keySelectorOut = keySelector;
+		return isAscending ? container.OrderBy(keySelector) : container.OrderByDescending(keySelector);
+	}
+}


### PR DESCRIPTION
I've gone ahead and implemented a rudimentary version of what was requested on #109 - I believe some work is still necessary here and I'm willing to do it, though I'd love some guidance.

The goal is to have a separate VoidList for just regex patterns, you can add as many as you want. I also added an offworld toggle to only apply the regex block to offworld characters (this could help preventing accidental matches).

My implementation seems to work just fine though I haven't quite figured out how to force a refresh properly so usability is a bit confusing at the moment. When disabling a regex, blocked characters don't get re-rendered until you walk away and walk back to them, this might be a game limitation though?

I also think maybe incorporating a whitelist check might be a good idea.. If a character matches a regex but is whitelisted it might be wise to allow that?

Let me know what changes you want and I'd be happy to make them! I tried my best to keep performance reasonable given the nature of the operation.

<img width="732" height="510" alt="image" src="https://github.com/user-attachments/assets/fae62745-dfb9-4825-8af3-52800d7d5038" />
