### PR TITLE
Add per-player public chat toggle to void list

### DIFF
--- a/Visibility/Handlers/ChatHandler.cs
+++ b/Visibility/Handlers/ChatHandler.cs
@@ -6,6 +6,7 @@ using Dalamud.Game.Text;
 using Dalamud.Game.Text.SeStringHandling.Payloads;
 
 using Visibility.Configuration;
+using Visibility.Void;
 
 
 namespace Visibility.Handlers;
@@ -49,12 +50,33 @@ public class ChatHandler: IDisposable
 			return;
 		}
 
-		if (this.configuration.VoidList.Any(x =>
-			    x.HomeworldId ==
-			    (isEmoteType ? emotePlayerPayload?.World.RowId : playerPayload?.World.RowId)
-			    && x.Name == (isEmoteType ? emotePlayerPayload?.PlayerName : playerPayload?.PlayerName)))
+		PlayerPayload? payload = isEmoteType ? emotePlayerPayload : playerPayload;
+		uint? worldId = payload?.World.RowId;
+		string? name = payload?.PlayerName;
+
+		VoidItem? match = this.configuration.VoidList
+			.FirstOrDefault(x => x.HomeworldId == worldId && x.Name == name);
+
+		if (match == null)
 		{
-			message.PreventOriginal();
+			return;
 		}
+
+		if (match.ShowPublicChat && IsPublicChannel(message.LogKind))
+		{
+			return;
+		}
+
+		message.PreventOriginal();
 	}
+
+	private static bool IsPublicChannel(XivChatType chatType) => chatType is
+		XivChatType.Say or
+		XivChatType.Shout or
+		XivChatType.Yell or
+		XivChatType.CustomEmote or
+		XivChatType.StandardEmote or
+		XivChatType.Party or
+		XivChatType.CrossParty or
+		XivChatType.Alliance;
 }

--- a/Visibility/Languages/de-DE/strings.json
+++ b/Visibility/Languages/de-DE/strings.json
@@ -45,6 +45,8 @@
   "ColumnWorld": "Welt",
   "ColumnDate": "Datum",
   "ColumnReason": "Begründung",
+  "ColumnPublicChat": "Öffentlicher Chat",
+  "ColumnPublicChatTooltip": "Zeigt Sagen-, Rufen-, Schreien-, Emote-, Gruppen- und Allianz-Nachrichten dieses Spielers an. Flüster-, Freie-Gesellschaft-, Kontaktkreis- und alle anderen Kanäle bleiben ausgeblendet.",
   "ColumnAction": "Aktion",
   "OptionLanguage": "Sprache",
   "LanguageName": "Deutsch",

--- a/Visibility/Languages/en-US/strings.json
+++ b/Visibility/Languages/en-US/strings.json
@@ -45,6 +45,8 @@
   "ColumnWorld": "World",
   "ColumnDate": "Date",
   "ColumnReason": "Reason",
+  "ColumnPublicChat": "Public chat",
+  "ColumnPublicChatTooltip": "Show this player's say, shout, yell, emote, party and alliance messages. Tells, free company, linkshell and all other channels stay hidden.",
   "ColumnAction": "Action",
   "OptionLanguage": "Language",
   "LanguageName": "English",

--- a/Visibility/Languages/es-ES/strings.json
+++ b/Visibility/Languages/es-ES/strings.json
@@ -45,6 +45,8 @@
   "ColumnWorld": "Mundo",
   "ColumnDate": "Fecha",
   "ColumnReason": "Razón",
+  "ColumnPublicChat": "Chat público",
+  "ColumnPublicChatTooltip": "Muestra los mensajes de say, shout, yell, emotes, party y alianza de este jugador. Los tells, los mensajes de FC y linkshell y todos los demás canales permanecen ocultos.",
   "ColumnAction": "Acción",
   "OptionLanguage": "Idioma",
   "LanguageName": "Español",

--- a/Visibility/Languages/fr-FR/strings.json
+++ b/Visibility/Languages/fr-FR/strings.json
@@ -45,6 +45,8 @@
   "ColumnWorld": "Monde",
   "ColumnDate": "Date",
   "ColumnReason": "Motif",
+  "ColumnPublicChat": "Chat public",
+  "ColumnPublicChatTooltip": "Affiche les messages dire, crier, hurler, emotes, équipe et alliance de ce joueur. Les messages privés, de compagnie libre, de contact et de tous les autres canaux restent masqués.",
   "ColumnAction": "Action",
   "OptionLanguage": "Langue",
   "LanguageName": "Français",

--- a/Visibility/Languages/it-IT/strings.json
+++ b/Visibility/Languages/it-IT/strings.json
@@ -45,6 +45,8 @@
   "ColumnWorld": "Mondo",
   "ColumnDate": "Data",
   "ColumnReason": "Motivo",
+  "ColumnPublicChat": "Chat pubblica",
+  "ColumnPublicChatTooltip": "Mostra i messaggi say, shout, yell, emote, gruppo e alleanza di questo giocatore. I tell, i messaggi di FC e linkshell e tutti gli altri canali restano nascosti.",
   "ColumnAction": "Azione",
   "OptionLanguage": "Lingua",
   "LanguageName": "Italiano",

--- a/Visibility/Languages/ja-JP/strings.json
+++ b/Visibility/Languages/ja-JP/strings.json
@@ -45,6 +45,8 @@
   "ColumnWorld": "ワールド",
   "ColumnDate": "日付",
   "ColumnReason": "理由",
+  "ColumnPublicChat": "公開チャット",
+  "ColumnPublicChatTooltip": "このプレイヤーのSay、Shout、Yell、エモート、パーティ、アライアンスのメッセージを表示します。テル、フリーカンパニー、リンクシェル、その他すべてのチャンネルのメッセージは非表示のままです。",
   "ColumnAction": "動作",
   "OptionLanguage": "言語",
   "LanguageName": "日本語",

--- a/Visibility/Languages/pt-BR/strings.json
+++ b/Visibility/Languages/pt-BR/strings.json
@@ -45,6 +45,8 @@
   "ColumnWorld": "Mundo",
   "ColumnDate": "Data",
   "ColumnReason": "Motivo",
+  "ColumnPublicChat": "Chat público",
+  "ColumnPublicChatTooltip": "Mostra as mensagens de say, shout, yell, emotes, party e aliança deste jogador. Tells, mensagens de FC e linkshell e todos os outros canais continuam ocultos.",
   "ColumnAction": "Ação",
   "OptionLanguage": "Idioma",
   "LanguageName": "Português",

--- a/Visibility/Languages/ru-RU/strings.json
+++ b/Visibility/Languages/ru-RU/strings.json
@@ -45,6 +45,8 @@
   "ColumnWorld": "Мир",
   "ColumnDate": "Дата",
   "ColumnReason": "Причина",
+  "ColumnPublicChat": "Общий чат",
+  "ColumnPublicChatTooltip": "Показывать сообщения этого игрока в say, shout, yell, эмоции, группе и альянсе. Личные сообщения (tell), сообщения FC и linkshell, а также все остальные каналы останутся скрытыми.",
   "ColumnAction": "Действие",
   "OptionLanguage": "Язык",
   "LanguageName": "Русский",

--- a/Visibility/Languages/sv-SE/strings.json
+++ b/Visibility/Languages/sv-SE/strings.json
@@ -45,6 +45,8 @@
   "ColumnWorld": "Värld",
   "ColumnDate": "Datum",
   "ColumnReason": "Anledning",
+  "ColumnPublicChat": "Offentlig chatt",
+  "ColumnPublicChatTooltip": "Visar denna spelares meddelanden i say, shout, yell, emotes, grupp och allians. Tells, FC- och linkshell-meddelanden samt alla andra kanaler förblir dolda.",
   "ColumnAction": "Handling",
   "OptionLanguage": "Språk",
   "LanguageName": "svenska",

--- a/Visibility/Languages/zh-CN/strings.json
+++ b/Visibility/Languages/zh-CN/strings.json
@@ -45,6 +45,8 @@
   "ColumnWorld": "服务器",
   "ColumnDate": "日期",
   "ColumnReason": "原因",
+  "ColumnPublicChat": "公共聊天",
+  "ColumnPublicChatTooltip": "显示该玩家的说话、呼喊、喊话、情感动作、小队和团队消息。密语、部队、通讯贝以及所有其他频道的消息仍将被隐藏。",
   "ColumnAction": "操作",
   "OptionLanguage": "语言",
   "LanguageName": "简体中文",

--- a/Visibility/Languages/zh-TW/strings.json
+++ b/Visibility/Languages/zh-TW/strings.json
@@ -45,6 +45,8 @@
   "ColumnWorld": "服務器",
   "ColumnDate": "日期",
   "ColumnReason": "原因",
+  "ColumnPublicChat": "公共聊天",
+  "ColumnPublicChatTooltip": "顯示該玩家的說話、呼喊、喊話、情感動作、小隊和團隊訊息。密語、部隊、通訊貝以及所有其他頻道的訊息仍會被隱藏。",
   "ColumnAction": "操作",
   "OptionLanguage": "語言",
   "LanguageName": "繁體中文",

--- a/Visibility/Localization.cs
+++ b/Visibility/Localization.cs
@@ -183,6 +183,11 @@ public class Localization
 	public string ColumnWorld => this.GetString("ColumnWorld", this.CurrentLanguage);
 	public string ColumnDate => this.GetString("ColumnDate", this.CurrentLanguage);
 	public string ColumnReason => this.GetString("ColumnReason", this.CurrentLanguage);
+	public string ColumnPublicChat => this.GetString("ColumnPublicChat", this.CurrentLanguage);
+
+	public string ColumnPublicChatTooltip =>
+		this.GetString("ColumnPublicChatTooltip", this.CurrentLanguage);
+
 	public string ColumnAction => this.GetString("ColumnAction", this.CurrentLanguage);
 	public string OptionLanguage => this.GetString("OptionLanguage", this.CurrentLanguage);
 	public string LanguageName => this.GetString("LanguageName", this.CurrentLanguage);

--- a/Visibility/Void/VoidItem.cs
+++ b/Visibility/Void/VoidItem.cs
@@ -41,6 +41,7 @@ public class VoidItem()
 	public uint HomeworldId { get; set; }
 	public string Reason { get; set; } = string.Empty;
 	public bool Manual { get; set; }
+	public bool ShowPublicChat { get; set; }
 
 	[JsonConstructor]
 	public VoidItem(
@@ -52,7 +53,8 @@ public class VoidItem()
 		DateTime time,
 		uint homeworldId,
 		string reason,
-		bool manual): this()
+		bool manual,
+		bool showPublicChat): this()
 	{
 		this.Version = version;
 		this.Id = id;
@@ -62,5 +64,6 @@ public class VoidItem()
 		this.HomeworldId = homeworldId;
 		this.Reason = reason;
 		this.Manual = manual;
+		this.ShowPublicChat = showPublicChat;
 	}
 }

--- a/Visibility/Windows/VoidItemList.cs
+++ b/Visibility/Windows/VoidItemList.cs
@@ -58,7 +58,7 @@ public class VoidItemList: Window
 	{
 		if (!ImGui.BeginTable(
 			    this.isWhitelist ? "WhitelistTable" : "VoidListTable",
-			    6,
+			    this.isWhitelist ? 6 : 7,
 			    ImGuiTableFlags.RowBg | ImGuiTableFlags.ScrollY | ImGuiTableFlags.Sortable))
 		{
 			return;
@@ -71,6 +71,14 @@ public class VoidItemList: Window
 			this.pluginLocalization.ColumnDate,
 			ImGuiTableColumnFlags.DefaultSort);
 		ImGui.TableSetupColumn(this.pluginLocalization.ColumnReason);
+
+		if (!this.isWhitelist)
+		{
+			ImGui.TableSetupColumn(
+				this.pluginLocalization.ColumnPublicChat,
+				ImGuiTableColumnFlags.NoSort);
+		}
+
 		ImGui.TableSetupColumn(this.pluginLocalization.ColumnAction, ImGuiTableColumnFlags.NoSort);
 		ImGui.TableSetupScrollFreeze(0, 1);
 		ImGui.TableHeadersRow();
@@ -123,6 +131,24 @@ public class VoidItemList: Window
 			ImGui.Text(item.Time.ToString(CultureInfo.CurrentCulture));
 			ImGui.TableNextColumn();
 			ImGui.TextUnformatted(item.Reason);
+
+			if (!this.isWhitelist)
+			{
+				ImGui.TableNextColumn();
+				bool showPublicChat = item.ShowPublicChat;
+
+				if (ImGui.Checkbox($"##showPublicChat{item.Name}{item.HomeworldId}", ref showPublicChat))
+				{
+					item.ShowPublicChat = showPublicChat;
+					this.configuration.Save();
+				}
+
+				if (ImGui.IsItemHovered())
+				{
+					ImGui.SetTooltip(this.pluginLocalization.ColumnPublicChatTooltip);
+				}
+			}
+
 			ImGui.TableNextColumn();
 
 			if (ImGui.Button($"{this.pluginLocalization.OptionRemovePlayer}##{item.Name}"))
@@ -207,6 +233,12 @@ public class VoidItemList: Window
 		ImGui.TableNextColumn();
 		ImGui.TableNextColumn();
 		ImGui.InputText("###reason", this.buffer[3]);
+
+		if (!this.isWhitelist)
+		{
+			ImGui.TableNextColumn();
+		}
+
 		ImGui.TableNextColumn();
 
 		if (ImGui.Button(this.pluginLocalization.OptionAddPlayer))


### PR DESCRIPTION
Voiding a player currently silences them on every channel, tells included. This
adds a per-player opt-in so you can keep someone's model hidden and their tells
blocked while still seeing them talk in the world and in duties.

Adds a **Public chat** column to the VoidList window with a checkbox per entry.

| State | Result |
|---|---|
| Unticked (default) | Unchanged. Every message from them is hidden |
| Ticked | Say, shout, yell, emotes, party, cross-world party and alliance are shown |

Tells, free company, linkshells and every other channel stay hidden in both
states.

`VoidItem.ShowPublicChat` defaults to `false`, so existing configs behave
exactly as before. No version bump, no migration.

Both new keys are added to all 11 locale files, because `Localization.GetString`
falls back to the key name rather than English. The non-English wording is a
best-effort pass; happy to defer to Crowdin on the phrasing.
